### PR TITLE
Added AppRequest object and AppRequests connection to users

### DIFF
--- a/lib/fb_graph.rb
+++ b/lib/fb_graph.rb
@@ -60,6 +60,7 @@ require 'fb_graph/work'
 
 require 'fb_graph/node'
 require 'fb_graph/album'
+require 'fb_graph/app_request'
 require 'fb_graph/application'
 require 'fb_graph/checkin'
 require 'fb_graph/comment'

--- a/lib/fb_graph/app_request.rb
+++ b/lib/fb_graph/app_request.rb
@@ -1,0 +1,16 @@
+module FbGraph
+  class AppRequest < Node
+
+    attr_accessor :application, :created_time, :data, :from, :message, :to
+
+    def initialize(identifier, attributes = {})
+      super
+      @application  = Application.new(attributes[:application].delete(:id), attributes[:application])
+      @created_time = attributes[:created_time]
+      @data         = attributes[:data]
+      @from         = User.new(attributes[:from].delete(:id), attributes[:from])
+      @message      = attributes[:message]
+      @to           = User.new(attributes[:to].delete(:id), attributes[:to])
+    end
+  end
+end

--- a/lib/fb_graph/connections/app_requests.rb
+++ b/lib/fb_graph/connections/app_requests.rb
@@ -1,0 +1,14 @@
+module FbGraph
+  module Connections
+    module AppRequests
+      def app_requests(options = {})
+        app_requests = self.connection(:apprequests, options)
+        app_requests.map! do |app_request|
+          AppRequest.new(app_request.delete(:id), app_request.merge(
+            :access_token => options[:access_token] || self.access_token
+          ))
+        end
+      end
+    end
+  end
+end

--- a/lib/fb_graph/user.rb
+++ b/lib/fb_graph/user.rb
@@ -3,6 +3,7 @@ module FbGraph
     include Connections::Accounts
     include Connections::Activities
     include Connections::Albums
+		include Connections::AppRequests
     include Connections::Books
     include Connections::Checkins
     include Connections::Events


### PR DESCRIPTION
Hello,

I have added a new fb_graph object: AppRequest and a new connection: AppRequests. I have had to do so, because facebook does not delete application requests which users have accepted -as described here: http://developers.facebook.com/docs/reference/dialogs/requests/.

I hope my work can help, because yours has helped me very much indeed.

Thank you for this wonderful gem.
