### PR TITLE
Likes is an integer in Posts...

### DIFF
--- a/lib/fb_graph/collection.rb
+++ b/lib/fb_graph/collection.rb
@@ -9,7 +9,7 @@ module FbGraph
       when Hash
         collection[:data] ||= []
         collection
-      when nil
+      when nil, Integer
         collection = {:data => [], :count => 0}
       else
         raise ArgumentError.new("Invalid collection")


### PR DESCRIPTION
As such I'm just adding a lil hack to treat integer Collections like nil collections.
Exception being caused by https://github.com/blaines/fb_graph/blob/master/lib/fb_graph/post.rb#L66
