### PR TITLE
More granularity for Exceptions

### DIFF
--- a/lib/fb_graph/exception.rb
+++ b/lib/fb_graph/exception.rb
@@ -1,6 +1,40 @@
 module FbGraph
   class Exception < StandardError
     attr_accessor :code, :type, :message
+
+    ERROR_HEADER_MATCHERS = {
+      /invalid_token/ => "InvalidToken",
+      /invalid_request/ => "InvalidRequest"
+    }
+
+    def self.handle_httpclient_error(response, headers)
+      return nil unless response[:error]
+
+      # Check the WWW-Authenticate header, since it seems to be more standardized than the response
+      # body error information.
+      if www_authenticate = headers["WWW-Authenticate"]
+        # Session expiration/invalidation is very common. Check for that first.
+        if www_authenticate =~ /invalid_token/ && response[:error][:message] =~ /session has been invalidated/
+          raise InvalidSession.new("#{response[:error][:type]} :: #{response[:error][:message]}")
+        end
+
+        ERROR_HEADER_MATCHERS.keys.each do |matcher|
+          if matcher =~ www_authenticate
+            exception_class = FbGraph::const_get(ERROR_HEADER_MATCHERS[matcher])
+            raise exception_class.new("#{response[:error][:type]} :: #{response[:error][:message]}")
+          end
+        end
+      end
+
+      # If we can't match on WWW-Authenticate, use the type
+      case response[:error][:type]
+      when /OAuth/
+        raise Unauthorized.new("#{response[:error][:type]} :: #{response[:error][:message]}")
+      else
+        raise BadRequest.new("#{response[:error][:type]} :: #{response[:error][:message]}")
+      end
+    end
+
     def initialize(code, message, body = '')
       @code = code
       if body.blank?
@@ -30,4 +64,10 @@ module FbGraph
       super 404, message, body
     end
   end
+
+  class InvalidToken < Unauthorized; end
+
+  class InvalidSession < InvalidToken; end
+
+  class InvalidRequest < BadRequest; end
 end

--- a/lib/fb_graph/node.rb
+++ b/lib/fb_graph/node.rb
@@ -120,21 +120,12 @@ module FbGraph
           _response_.map!(&:with_indifferent_access)
         when Hash
           _response_ = _response_.with_indifferent_access
-          handle_httpclient_error(_response_) if _response_[:error]
+          Exception.handle_httpclient_error(_response_, response.headers) if _response_[:error]
           _response_
         end
       end
     rescue JSON::ParserError
       raise Exception.new(response.status, 'Unparsable Error Response')
-    end
-
-    def handle_httpclient_error(response)
-      case response[:error][:type]
-      when /OAuth/
-        raise Unauthorized.new("#{response[:error][:type]} :: #{response[:error][:message]}")
-      else
-        raise BadRequest.new("#{response[:error][:type]} :: #{response[:error][:message]}")
-      end
     end
   end
 end


### PR DESCRIPTION
I wanted more exceptions so I could differentiate in my app and handle things like expired sessions.

For this patch I look at the WWW-Authenticate header which seems to have more error code information than the <code>error[:code]</code> or <code>error[:message]</code> fields.

Please tell me what you think.
