### PR TITLE
adding like! to likable objects

### DIFF
--- a/lib/fb_graph/checkin.rb
+++ b/lib/fb_graph/checkin.rb
@@ -44,5 +44,14 @@ module FbGraph
     def self.search(options = {})
       super(nil, options)
     end
+    
+    def like!(options = {})
+      post(options)
+    end
+
+    def unlike!(options = {})
+      destroy(options)
+    end
+    
   end
 end


### PR DESCRIPTION
Would it be possible to add a simple method similar to comments for liking objects that can can be liked? I think there are a handful of these. 

For example, checkins can be liked http://developers.facebook.com/docs/reference/api/checkin/ 

likes

Create

You can like a checkin by issuing a HTTP POST request to CHECKIN_ID/likes connection with the publish_stream permission. No parameters are necessary.

If the write is successful, you get the following return.

Description  Type
If the like succeeded   boolean
Delete

You can unlike an checkin by issuing an HTTP DELETE request to the CHECKIN_ID/like connection with the publish_stream permission.

If the delete is successful, you get the following return.

Description  Type
If the unlike succeeded boolean
