### PR TITLE
Adds FbGraph::Application.app -- retrieve application from access token

### DIFF
--- a/lib/fb_graph/application.rb
+++ b/lib/fb_graph/application.rb
@@ -63,7 +63,11 @@ module FbGraph
       access_token_without_auto_fetch ||
       self.secret && get_access_token
     end
+
     alias_method_chain :access_token, :auto_fetch
 
+    def self.app(access_token)
+      new('app', :access_token => access_token)
+    end
   end
 end


### PR DESCRIPTION
This trivial change will allow me to identify the application which is specified an an access token. In my scenario, I would have sent this access token to my API from mobile app and I want to ensure that the access token wasn't granted to another application and being used to spoof mine.

Similar to FbGraph::User.me.

Let me know if there's anything else I need to do.

Matt Woodward
