### PR TITLE
add installed attribute to the user object

### DIFF
--- a/lib/fb_graph/user.rb
+++ b/lib/fb_graph/user.rb
@@ -46,7 +46,7 @@ module FbGraph
     attr_accessor :name, :first_name, :middle_name, :last_name, :gender, :locale, :languages, :link, :username, :third_party_id, :timezone, :updated_time, :verified, :about, :bio, :birthday, :education, :email, :hometown, :interested_in, :location, :political, :favorite_teams, :quotes, :relationship_status, :religion, :significant_other, :video_upload_limits, :website, :work
 
     # NOTE: below are non-documented
-    attr_accessor :sports,  :favorite_athletes, :inspirational_people, :address, :mobile_phone
+    attr_accessor :sports,  :favorite_athletes, :inspirational_people, :address, :mobile_phone, :installed
 
     def initialize(identifier, attributes = {})
       super
@@ -137,6 +137,7 @@ module FbGraph
         @address = Venue.new(attributes[:address])
       end
       @mobile_phone = attributes[:mobile_phone]
+      @installed = attributes[:installed]
     end
 
     def self.me(access_token)

--- a/spec/fb_graph/user_spec.rb
+++ b/spec/fb_graph/user_spec.rb
@@ -9,11 +9,13 @@ describe FbGraph::User, '.new' do
         :state => "Kanagawa",
         :country => "Japan"
       },
-      :mobile_phone => '810000000000'
+      :mobile_phone => '810000000000',
+      :installed => true
     }
     user = FbGraph::User.new(attributes.delete(:id), attributes)
     user.address.should == FbGraph::Venue.new(attributes[:address])
     user.mobile_phone.should == '810000000000'
+    user.installed.should be_true
   end
 
   it 'should support year-hidden birthday' do


### PR DESCRIPTION
Based on https://developers.facebook.com/docs/reference/rest/users.isAppUser/
isAppUser is now deprecated and installed field must be used.

"Please use the Graph API User object and GET /[UID]?fields=installed to check if a user is has TOSed that app."

This pull request add the installed attribute to the User Object.

It also can be used for the friends request : 
fb_user =  FbGraph::User.me(user.token)
fb_user.friends(:fields => "installed,name")
