### PR TITLE
Added support for "relationship" attribute when creating users via the friends connection

### DIFF
--- a/lib/fb_graph/connections/family.rb
+++ b/lib/fb_graph/connections/family.rb
@@ -4,7 +4,6 @@ module FbGraph
       def family(options = {})
         users = self.connection(:family, options)
         users.map! do |user|
-          FbGraph.logger.info(user.inspect)
           User.new(user[:id], user.merge(
             :access_token => options[:access_token] || self.access_token
           ))


### PR DESCRIPTION
Hey Guys,

I added an "relationship" attr_accessor and the appropriate initialization in User.rb so that the relationships would be properly set when using the friends connection.

Your tests actually referenced the relationship attribute, but I didn't see it implemented.

Let me know if you need anything else or if I'm missing something.

Thanks!

Charlie
