### PR TITLE
Addition of exceptions for facebook ad api failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fb_graph (2.2.3)
+    fb_graph (2.2.5)
       httpclient (>= 2.2.0.2)
       rack-oauth2 (>= 0.9.4)
 
@@ -28,19 +28,13 @@ GEM
     addressable (2.2.6)
     attr_required (0.0.3)
     builder (3.0.0)
-    configatron (2.8.4)
-      yamler (>= 0.1.0)
-    cover_me (1.2.0)
-      configatron
-      hashie
     crack (0.3.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    hashie (1.2.0)
     hike (1.2.1)
-    httpclient (2.2.3)
+    httpclient (2.2.4)
     i18n (0.6.0)
-    json (1.6.1)
+    json (1.6.5)
     multi_json (1.0.3)
     rack (1.3.5)
     rack-cache (1.1)
@@ -57,6 +51,7 @@ GEM
     rack-test (0.6.1)
       rack (>= 1.0)
     rake (0.9.2.2)
+    rcov (0.9.11)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
       rspec-expectations (~> 2.7.0)
@@ -73,16 +68,15 @@ GEM
     webmock (1.7.8)
       addressable (~> 2.2, > 2.2.5)
       crack (>= 0.1.7)
-    yamler (0.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   actionpack (>= 3.0.6)
-  cover_me (>= 1.2.0)
   fb_graph!
   jruby-openssl (>= 0.7)
   rake (>= 0.8)
+  rcov (>= 0.9)
   rspec (>= 2)
   webmock (>= 1.6.2)

--- a/spec/fb_graph/exception_spec.rb
+++ b/spec/fb_graph/exception_spec.rb
@@ -135,8 +135,145 @@ describe FbGraph::Exception, ".handle_httpclient_error" do
         }
       end
 
-      it "should raise a BadRequst exception" do
+      it "should raise a BadRequest exception" do
         lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::BadRequest)
+      end
+
+      context "with an Ads API Exception" do
+        context "of Could not save creative" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'Could not save creative',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a CreativeNotSaved exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::CreativeNotSaved)
+          end
+        end
+
+        context "of QueryLockTimeout" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'QueryLockTimeoutException',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a QueryLockTimeout exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::QueryLockTimeout)
+          end
+        end
+
+        context "of Could not create targeting spec" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'Could not create targeting spec',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a TargetingSpecNotSaved exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::TargetingSpecNotSaved)
+          end
+        end
+
+        context "of Could not fetch adgroups" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'Could not fetch adgroups',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a AdgroupFetchFailure exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::AdgroupFetchFailure)
+          end
+        end
+
+        context "of Failed to open process" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'Failed to open process',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a OpenProcessFailure exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::OpenProcessFailure)
+          end
+        end
+
+        context "of Could not commit transaction" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'Could not commit transaction',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a TransactionCommitFailure exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::TransactionCommitFailure)
+          end
+        end
+
+        context "of QueryErrorException" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'DB Error: QueryErrorException',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a QueryError exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::QueryError)
+          end
+        end
+
+        context "of QueryConnectionException" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'QueryConnectionException',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a QueryConnection exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::QueryConnection)
+          end
+        end
+
+        context "of QueryDuplicateKeyException" do
+          let(:parsed_response) do
+            {
+              :error => {
+                :message => 'QueryDuplicateKeyException',
+                :type => "Exception"
+              }
+            }
+          end
+
+          it "should raise a QueryDuplicateKey exception" do
+            lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, {})}.should raise_exception(FbGraph::QueryDuplicateKey)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Hello,

We've added a bunch of exceptions to handle the case of getting ad api failures back from Facebook that are not necessarily related to validation issues. In our testing and experience on production these exceptions come back from Facebook as errors on their end, and submitting the same request again a second (or third) time will eventually work. Because of this these new exceptions are using the HTTP status code 500 instead of 400 for a BadRequest. 

Also added are tests to cover these new exceptions and the entire test suite passes.

Let me know if this doesn't make sense or if we need to approach this a different way to fit in with your convention for the project. 

Thanks!
- Tim Gourley and Zack Adams
