### PR TITLE
Support Ruby's standard behavior on custom exceptions

### DIFF
--- a/lib/fb_graph/exception.rb
+++ b/lib/fb_graph/exception.rb
@@ -64,6 +64,8 @@ module FbGraph
         @message = response[:error][:message]
         @type = response[:error][:type]
       end
+
+      super message
     end
   end
 

--- a/spec/fb_graph/exception_spec.rb
+++ b/spec/fb_graph/exception_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe FbGraph::Exception do
+  it 'should properly set its message for inspect' do
+    err = FbGraph::Exception.new(400, 'This is the error message')
+    err.inspect.should == '#<FbGraph::Exception: This is the error message>'
+  end
+
   context 'when response body is given' do
     it 'should setup message and type from error' do
       err = FbGraph::Exception.new(400, 'This is the original message', {


### PR DESCRIPTION
Ruby's standard behavior for Exception#inspect is to show <ExceptionClass: ExceptionClass>
when no message is given and <ExceptionClass: message> if a message is given. Custom exceptions
should reflect this behavior.

The problem is fairly obvious when, for instance, using Resque: Instead of displaying the (helpful) Facebook error message, one merely gets "FbGraph::InvalidRequest" which is not helpful for debugging/bugfixing at all. The pull request fixes this issue by calling super at the end.
