### PR TITLE
handle mixed-case HTTP headers correctly, per the spec

### DIFF
--- a/lib/fb_graph/exception.rb
+++ b/lib/fb_graph/exception.rb
@@ -24,7 +24,9 @@ module FbGraph
 
       # Check the WWW-Authenticate header, since it seems to be more standardized than the response
       # body error information.
-      if www_authenticate = headers["WWW-Authenticate"]
+      # The complex lookup is needed to follow the HTTP spec - headers should be looked up
+      # without regard to case.
+      if www_authenticate = headers.select{ |name, value| name.upcase == "WWW-Authenticate".upcase }.values.first
         # Session expiration/invalidation is very common. Check for that first.
         if www_authenticate =~ /invalid_token/ && response[:error][:message] =~ /session has been invalidated/
           raise InvalidSession.new("#{response[:error][:type]} :: #{response[:error][:message]}")

--- a/spec/fb_graph/exception_spec.rb
+++ b/spec/fb_graph/exception_spec.rb
@@ -91,6 +91,18 @@ describe FbGraph::Exception, ".handle_httpclient_error" do
       it "should raise an InvalidToken exception" do
         lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, headers)}.should raise_exception(FbGraph::InvalidToken)
       end
+
+      context "with a variant capitalization of the header" do
+        let(:headers) do
+          {
+            "Www-Authenticate" => 'OAuth "Facebook Platform" "invalid_token" "Invalid OAuth access token."'
+          }
+        end
+
+        it "should raise an InvalidToken exception" do
+          lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, headers)}.should raise_exception(FbGraph::InvalidToken)
+        end
+      end
     end
 
     context "with an invalid request" do


### PR DESCRIPTION
The exception-parsing code falls over if the WWW-Authenticate header is capitalized in a non-standard way (Www-Authenticate, for instance). The HTTP spec requires case-insensitive lookup for headers.

I ran into this issue when testing FbGraph code with WebMock, which oh-so-helpfully "normalizes" headers to only have capital letters at the beginning of each dash-delimited word.
