### PR TITLE
Update ad_previews to match Facebook.

### DIFF
--- a/lib/fb_graph/ad_preview.rb
+++ b/lib/fb_graph/ad_preview.rb
@@ -4,7 +4,7 @@ module FbGraph
 
     def initialize(attributes = {})
       super
-      self.preview_data = attributes["0"]
+      self.preview_data = attributes[:data][0]
     end
   end
 end

--- a/lib/fb_graph/connections/ad_previews.rb
+++ b/lib/fb_graph/connections/ad_previews.rb
@@ -2,7 +2,7 @@ module FbGraph
   module Connections
     module AdPreviews
       def ad_previews(options = {})
-        ad_previews = self.post options.merge(:method => 'get', :connection => :adpreviews)
+        ad_previews = self.post options.merge(:method => 'get', :connection => :previews)
         AdPreview.new ad_previews.merge(:access_token => options[:access_token] || self.access_token)
       end
     end

--- a/spec/fb_graph/connections/ad_previews_spec.rb
+++ b/spec/fb_graph/connections/ad_previews_spec.rb
@@ -4,11 +4,11 @@ describe FbGraph::Connections::AdPreviews, '#ad_previews' do
   context 'when included by FbGraph::AdAccount' do
     context 'when access_token is given' do
       it 'should return ad_preview as FbGraph::AdPreview' do
-        mock_graph :post, 'act_123456789/adpreviews', 'ad_accounts/ad_previews/test_ad_previews'  do
+        mock_graph :post, 'act_123456789/previews', 'ad_accounts/previews/test_ad_previews'  do
           ad_account = FbGraph::AdAccount.new('act_123456789', :access_token => 'access_token')
-          ad_preview = ad_account.ad_previews(:access_token => 'access_token', :preview_spec => {})
+          ad_preview = ad_account.ad_previews(:access_token => 'access_token', :creative => {})
           ad_preview.should be_instance_of(FbGraph::AdPreview)
-          ad_preview.preview_data.should == 'hello world'
+          ad_preview.preview_data[:body].should == '<h1>hello world</h1>'
         end
       end
     end

--- a/spec/mock_json/ad_accounts/ad_previews/test_ad_previews.json
+++ b/spec/mock_json/ad_accounts/ad_previews/test_ad_previews.json
@@ -1,4 +1,0 @@
-{
-	"0":"hello world",
-	"success":true
-}

--- a/spec/mock_json/ad_accounts/previews/test_ad_previews.json
+++ b/spec/mock_json/ad_accounts/previews/test_ad_previews.json
@@ -1,0 +1,7 @@
+{
+  "data":[
+    {
+      "body":"<h1>hello world</h1>"
+    }
+   ]
+}


### PR DESCRIPTION
Facebook has changed the request and response format for their (unpublished) ad_previews API call. We figured out what it should look like and updated the fb_graph requests to match it.
