### PR TITLE
Update the AdPreviews connection

### DIFF
--- a/lib/fb_graph/connections/ad_previews.rb
+++ b/lib/fb_graph/connections/ad_previews.rb
@@ -2,7 +2,7 @@ module FbGraph
   module Connections
     module AdPreviews
       def ad_previews(options = {})
-        ad_previews = self.post options.merge(:method => 'get', :connection => :previews)
+        ad_previews = self.post options.merge(:method => 'get', :connection => :generatepreviews)
         AdPreview.new ad_previews.merge(:access_token => options[:access_token] || self.access_token)
       end
     end

--- a/spec/fb_graph/connections/ad_previews_spec.rb
+++ b/spec/fb_graph/connections/ad_previews_spec.rb
@@ -4,7 +4,7 @@ describe FbGraph::Connections::AdPreviews, '#ad_previews' do
   context 'when included by FbGraph::AdAccount' do
     context 'when access_token is given' do
       it 'should return ad_preview as FbGraph::AdPreview' do
-        mock_graph :post, 'act_123456789/previews', 'ad_accounts/previews/test_ad_previews'  do
+        mock_graph :post, 'act_123456789/generatepreviews', 'ad_accounts/previews/test_ad_previews'  do
           ad_account = FbGraph::AdAccount.new('act_123456789', :access_token => 'access_token')
           ad_preview = ad_account.ad_previews(:access_token => 'access_token', :creative => {})
           ad_preview.should be_instance_of(FbGraph::AdPreview)


### PR DESCRIPTION
Facebook has (once again) changed the URL for the AdPreview connection. This is an update for that.
