### PR TITLE
Fixing link attribute for pages.

### DIFF
--- a/lib/fb_graph/page/category_attributes.rb
+++ b/lib/fb_graph/page/category_attributes.rb
@@ -71,6 +71,9 @@ module FbGraph
         @@attributes[:raw].each do |key|
           self.send :"#{key}=", attributes[key]
         end
+
+        self.link ||= "http://facebook.com/#{attributes[:username]}"
+        
         @@attributes[:symbols].each do |key|
           self.send :"#{key}=", []
           if attributes[key]


### PR DESCRIPTION
Facebook stopped providing link attribute for some pages. Here's the fix. All tests are green.
