### PR TITLE
Add support for event invitation

### DIFF
--- a/lib/fb_graph/connections/invited.rb
+++ b/lib/fb_graph/connections/invited.rb
@@ -9,6 +9,9 @@ module FbGraph
           )
         end
       end
+      def invite!(options = {})
+        post options.merge(:connection => :invited)
+      end
     end
   end
 end

--- a/spec/fb_graph/connections/invited_spec.rb
+++ b/spec/fb_graph/connections/invited_spec.rb
@@ -1,11 +1,23 @@
 require 'spec_helper'
 
-describe FbGraph::Connections::Invited, '#invited' do
-  it 'should return invited users as FbGraph::User' do
-    mock_graph :get, 'smartday/invited', 'events/invited/smartday_private', :access_token => 'access_token' do
-      users = FbGraph::Event.new('smartday', :access_token => 'access_token').invited
-      users.each do |user|
-        user.should be_instance_of(FbGraph::User)
+describe FbGraph::Connections::Invited do
+  describe '#invited' do
+    it 'should return invited users as FbGraph::User' do
+      mock_graph :get, 'smartday/invited', 'events/invited/smartday_private', :access_token => 'access_token' do
+        users = FbGraph::Event.new('smartday', :access_token => 'access_token').invited
+        users.each do |user|
+          user.should be_instance_of(FbGraph::User)
+        end
+      end
+    end
+  end
+
+  describe '#invite!' do
+    let(:event) { FbGraph::Event.new('smartday', :access_token => 'access_token') }
+    it 'should invite a single user to an event' do
+      mock_graph :post, 'smartday/invited', 'true', :access_token => 'access_token', :params => {
+        :users => "user_id" } do
+          event.invite!(:users => "user_id").should be_true
       end
     end
   end


### PR DESCRIPTION
Currently fb_graph can query for an event invite list, but can't invite other users to an event.
I added a method for that

```
Event#invite!(:users => "user1_id, user2_id, user3_id")
```
