### PR TITLE
Don't assign data to objects unless they're an object

### DIFF
--- a/lib/fb_graph/open_graph/action.rb
+++ b/lib/fb_graph/open_graph/action.rb
@@ -21,7 +21,7 @@ module FbGraph
         @objects = {}
         if attributes[:data]
           attributes[:data].each do |key, _attributes_|
-            @objects[key] = Object.new _attributes_[:id], _attributes_
+            @objects[key] = Object.new _attributes_[:id], _attributes_ if _attributes_.is_a? Hash
           end
         end
         @objects = @objects.with_indifferent_access


### PR DESCRIPTION
The data coming back can be additional attributes that have been sent to Facebook on that particular action.  This makes sure that we don't try to create an object out of an integer or string.
