### PR TITLE
Adding ETag support for Graph API requests to improve request/response.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -259,6 +259,32 @@ Not tested well yet.
 Sample is here.
 https://gist.github.com/752914
 
+== ETag support
+
+Facebook supports ETags to increase performance of request-response on Graph API. This support was added for working with large amounts of requests. More information from FB can be found here: 
+http://developers.facebook.com/docs/reference/ads-api/etags-reference/
+
+An example of using an ETags.
+  
+  # Request an object like normal
+  fb_camp = FbGraph::AdCampaign.new('1234567', 
+  {:access_token => 'access_token_12345'}).fetch 
+  
+  # Take note of etag
+  fb_camp_etag = fb_camp.etag
+
+  #Request an object with etag next time to check for updates
+  fb_camp = FbGraph::AdCampaign.new('1234567', 
+  {:access_token => 'access_token_12345' ,:if_none_match => fb_camp_etag }).fetch 
+  
+  if fb_camp.status_code = 304
+    #use application object, no update from FB
+  else
+    #use fb_graph/FB response
+    # store fb_camp.etag for if_none_match on next request
+  end 
+
+
 === More Examples?
 
 See GitHub wiki for more examples.

--- a/lib/fb_graph/node.rb
+++ b/lib/fb_graph/node.rb
@@ -3,21 +3,28 @@ require 'tempfile'
 module FbGraph
   class Node
     include Comparison
-
-    attr_accessor :identifier, :endpoint, :access_token, :raw_attributes
-
+    
+    attr_accessor :identifier, :endpoint, :access_token, :raw_attributes, :etag, :status_code, :if_none_match
+    
     def initialize(identifier, attributes = {})
       @identifier         = identifier
       @endpoint           = File.join(ROOT_URL, identifier.to_s)
       @access_token       = attributes[:access_token]
+      @if_none_match      = attributes[:if_none_match]
+      @etag               = attributes[:etag]
+      @status_code        = attributes[:status_code]
       @raw_attributes     = attributes
       @cached_collections = {}
     end
 
     def fetch(options = {})
       options[:access_token] ||= self.access_token if self.access_token
+      options[:if_none_match] ||= self.if_none_match if self.if_none_match
       _fetched_ = get(options)
       _fetched_[:access_token] ||= options[:access_token]
+      _fetched_[:if_none_match] = self.if_none_match
+      _fetched_[:etag] = self.etag
+      _fetched_[:status_code] = self.status_code
       self.class.new(_fetched_[:id], _fetched_)
     end
 
@@ -43,11 +50,19 @@ module FbGraph
       delete options
     end
 
+    def not_modified?
+      self.status_code == 304
+    end
+
     protected
 
     def get(params = {})
       handle_response do
-        http_client.get build_endpoint(params), build_params(params)
+        if if_none_match = params.delete(:if_none_match)
+          http_client.get build_endpoint(params), build_params(params), {'If-None-Match' => "\"#{if_none_match}\""}
+        else
+          http_client.get build_endpoint(params), build_params(params)
+        end
       end
     end
 
@@ -97,9 +112,9 @@ module FbGraph
       _params_ = params.dup
       _params_[:access_token] ||= self.access_token
       _params_.delete_if do |k, v|
-        v.blank? &&
-        # NOTE: allow "key=false" in params (ex. for test user creation, it supports "installed=false")
-        v != false
+      v.blank? &&
+      # NOTE: allow "key=false" in params (ex. for test user creation, it supports "installed=false")
+      v != false
       end
       _params_.each do |key, value|
         next if value.blank?
@@ -139,11 +154,19 @@ module FbGraph
           # NOTE: User#app_request! returns ID as a JSON string not as a JSON object..
           response.body.gsub('"', '')
         else
-          _response_ = JSON.parse(response.body).with_indifferent_access
-          if (200...300).include?(response.status)
-            _response_
+          if response.status == 304
+            self.status_code = response.status
+            self.etag = nil
+            {}
           else
-            Exception.handle_httpclient_error(_response_, response.headers)
+            _response_ = JSON.parse(response.body).with_indifferent_access
+            if (200...300).include?(response.status)
+              self.etag = response.headers['ETag'].gsub('"','') if response.headers['ETag']
+              self.status_code = response.status
+              _response_
+            else
+              Exception.handle_httpclient_error(_response_, response.headers)
+            end
           end
         end
       end

--- a/spec/fb_graph/node_spec.rb
+++ b/spec/fb_graph/node_spec.rb
@@ -11,12 +11,24 @@ describe FbGraph::Node do
       FbGraph::Node.new('matake', :access_token => 'access_token').access_token.should == 'access_token'
     end
 
+    it 'should support if_none_match option' do
+      FbGraph::Node.new('matake', :if_none_match => 'if_none_match').if_none_match.should == 'if_none_match'
+    end
+
+    it 'should support etag option' do
+      FbGraph::Node.new('matake', :etag=> 'etag').etag.should == 'etag'
+    end
+    
+    it 'should support status_code option' do
+      FbGraph::Node.new('matake', :status_code=> 'status_code').status_code.should == 'status_code'
+    end
+
     it 'should store raw attributes' do
       attributes = {:key => :value}
       FbGraph::Node.new(12345, attributes).raw_attributes.should == attributes
     end
   end
-
+  
   describe '#build_params' do
     let(:node) { node = FbGraph::Node.new('identifier') }
     let(:tmpfile) { Tempfile.new('tmp') }
@@ -61,7 +73,32 @@ describe FbGraph::Node do
     end
   end
 
+ describe '#get' do
+  it "should pass If-Not-Match header if provided" do
+    stub_request(:get, "https://graph.facebook.com/identifier?access_token=12345")\
+      .with(:headers => {'If-None-Match'=>'"54321foo"'}).to_return(:status => 304, :body => "", :headers => {})
+      node = FbGraph::Node.fetch('identifier', :access_token => '12345', :if_none_match => '54321foo')
+  end
+
+  it "should not pass If-Not-Match header if not provided" do
+    stub_request(:get, "https://graph.facebook.com/identifier?access_token=12345")\
+      .with(:headers => {}).to_return(:status => 200, :body => '{"data": []}', :headers => {})
+      node = FbGraph::Node.fetch('identifier', :access_token => '12345')
+  end
+ end
+
   describe '#handle_response' do
+
+   let(:not_modified_response) {
+      mock(HTTP::Message, :status => 304, :body => '')
+    }
+   let(:modified_response) {
+        mock(HTTP::Message, :body =>  "{\"key1\":\"12345\"}",
+                            :status => 200,
+                            :headers => {'ETag' => '5431foobar'}
+        )
+   }     
+
     it 'should handle null/false response' do
       node = FbGraph::Node.new('identifier')
       null_response = node.send :handle_response do
@@ -85,6 +122,25 @@ describe FbGraph::Node do
           HTTP::Message.new_response 'invalid'
         end
       end.should raise_error FbGraph::Exception
+    end
+    
+    it 'should set ETag and HTTP Status for reponses with 2xx status' do
+      node = FbGraph::Node.new('identifier')
+      node.send :handle_response do
+        modified_response
+      end
+      node.etag.should == '5431foobar'
+      node.status_code.should == 200
+      node.not_modified?.should == false
+    end
+
+    it 'should set status_code when status is 304' do
+      node = FbGraph::Node.new('identifier')
+      node.send :handle_response do
+        not_modified_response
+      end
+      node.status_code.should == 304
+      node.not_modified?.should == true
     end
   end
 


### PR DESCRIPTION
See README for examples and more information. Or review this link: http://developers.facebook.com/docs/reference/ads-api/etags-reference/

Thanks,
Hank
