### PR TITLE
Added support for lifetime_imps on AdCampaign

### DIFF
--- a/lib/fb_graph/ad_campaign.rb
+++ b/lib/fb_graph/ad_campaign.rb
@@ -2,7 +2,7 @@ module FbGraph
   class AdCampaign < Node
     include Connections::AdGroups
 
-    attr_accessor :campaign_id, :account_id, :name, :start_time, :end_time, :updated_time, :daily_budget, :daily_imps, :campaign_status, :lifetime_budget
+    attr_accessor :campaign_id, :account_id, :name, :start_time, :end_time, :updated_time, :daily_budget, :daily_imps, :campaign_status, :lifetime_budget, :lifetime_imps
 
     def initialize(identifier, attributes = {})
       super
@@ -23,7 +23,7 @@ module FbGraph
     protected
 
     def set_attrs(attributes)
-      %w(campaign_id account_id name daily_budget daily_imps campaign_status lifetime_budget).each do |field|
+      %w(campaign_id account_id name daily_budget daily_imps campaign_status lifetime_budget lifetime_imps).each do |field|
         send("#{field}=", attributes[field.to_sym])
       end
 

--- a/spec/fb_graph/ad_campaign_spec.rb
+++ b/spec/fb_graph/ad_campaign_spec.rb
@@ -11,7 +11,8 @@ describe FbGraph::AdCampaign, '.new' do
       :end_time => "2011-07-14T16:00:00+00:00",
       :daily_budget => 20000,
       :campaign_status => 1,
-      :lifetime_budget => 100000
+      :lifetime_budget => 100000,
+      :lifetime_imps => 1000
     }
     ad_campaign = FbGraph::AdCampaign.new(attributes.delete(:id), attributes)
     ad_campaign.identifier.should == "6003266501234"
@@ -22,6 +23,7 @@ describe FbGraph::AdCampaign, '.new' do
     ad_campaign.daily_budget.should == 20000
     ad_campaign.campaign_status.should == 1
     ad_campaign.lifetime_budget.should == 100000
+    ad_campaign.lifetime_imps.should == 1000
   end
 
   it 'should handle integer, string, or iso8601 timestamps' do


### PR DESCRIPTION
Facebook mentions `lifetime_imps` in their [Premium Ads documentation](https://developers.facebook.com/docs/reference/ads-api/premium-via-api/). 

Added `lifetime_imps` as a supported attribute in `ad_campaign`, and updated the attribute test in `ad_campaign_spec`.
