### PR TITLE
Added support to pull reach estimates from specific AdGroups

### DIFF
--- a/lib/fb_graph/ad_group.rb
+++ b/lib/fb_graph/ad_group.rb
@@ -1,6 +1,7 @@
 module FbGraph
   class AdGroup < Node
     include Connections::AdCreatives
+    include Connections::ReachEstimates
 
     attr_accessor :ad_id, :campaign_id, :name, :adgroup_status, :bid_type, :max_bid, :targeting, :creative, :creative_ids, :adgroup_id,
       :end_time, :start_time, :updated_time, :bid_info, :disapprove_reason_descriptions

--- a/lib/fb_graph/reach_estimate.rb
+++ b/lib/fb_graph/reach_estimate.rb
@@ -6,6 +6,9 @@ module FbGraph
     def initialize(attributes = {})
       super
 
+      # everything in a data node when getting reach estimate through an AdGroup
+      attributes = attributes[:data] if attributes[:data]
+
       %w(users).each do |field|
         send("#{field}=", attributes[field.to_sym])
       end

--- a/spec/fb_graph/reach_estimate_spec.rb
+++ b/spec/fb_graph/reach_estimate_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe FbGraph::ReachEstimate, '.new' do
-  it 'should setup all supported attributes' do
-    attributes = {
+  let(:attributes) {
+    {
       :users => 5503300,
       :bid_estimations => [
         {
@@ -15,9 +15,28 @@ describe FbGraph::ReachEstimate, '.new' do
           :cpm_max => 14
         }
       ],
-      :imp_estimates => []
+        :imp_estimates => []
     }
+  }
+
+  let(:attributes_through_ad_group) {
+    {
+      :data => attributes
+    }
+  }
+  it 'should setup all supported attributes' do
     estimate = FbGraph::ReachEstimate.new(attributes)
+    estimate.users.should == 5503300
+    estimate.cpc_min.should == 27
+    estimate.cpc_median.should == 37
+    estimate.cpc_max.should == 48
+    estimate.cpm_min.should == 8
+    estimate.cpm_median.should == 11
+    estimate.cpm_max.should == 14
+  end
+
+  it 'should setup all supported attributes through AdGroup' do
+    estimate = FbGraph::ReachEstimate.new(attributes_through_ad_group)
     estimate.users.should == 5503300
     estimate.cpc_min.should == 27
     estimate.cpc_median.should == 37


### PR DESCRIPTION
[Reach Estimate](https://developers.facebook.com/docs/reference/ads-api/reachestimate/) can be pulled from given target spec (which `fb_graph` currently allows), or by a given AdGroup (which this pull request adds).

Thanks!
