### PR TITLE
Added support for query_templates on AdCreative

### DIFF
--- a/lib/fb_graph/ad_creative.rb
+++ b/lib/fb_graph/ad_creative.rb
@@ -21,7 +21,8 @@ module FbGraph
       :url_tags,
       :related_fan_page,
       :auto_update,
-      :action_spec
+      :action_spec,
+      :query_templates
     ]
 
     attr_accessor *ATTRS 

--- a/spec/fb_graph/ad_creative_spec.rb
+++ b/spec/fb_graph/ad_creative_spec.rb
@@ -23,7 +23,8 @@ describe FbGraph::AdCreative, '.new' do
       :url_tags => "url=tags",
       :related_fan_page => 5799040003,
       :auto_update => 1,
-      :action_spec => '{"action.type":["flightsim:fly"], "application":[174829001234]}'
+      :action_spec => '{"action.type":["flightsim:fly"], "application":[174829001234]}',
+      :query_templates => ["6"]
     }
     ad_creative = FbGraph::AdCreative.new(attributes.delete(:id), attributes)
     ad_creative.identifier.should == "6003590469668"
@@ -45,6 +46,7 @@ describe FbGraph::AdCreative, '.new' do
     ad_creative.related_fan_page.should == 5799040003
     ad_creative.auto_update.should == 1
     ad_creative.action_spec.should == '{"action.type":["flightsim:fly"], "application":[174829001234]}'
+    ad_creative.query_templates.should == ["6"] 
   end
 end
 


### PR DESCRIPTION
Some Ad Creatives created on Facebook before Action Spec have a `query_templates` parameter to determine the type of sponsored story. The [Creative Spec documentation](https://developers.facebook.com/docs/reference/ads-api/creative-specs/#action_specs_Sponsored_stories) mentions the different types. I added `query_templates` as an attribute on AdCreatives. 

Thanks!
