### PR TITLE
Added support for view tags on AdGroups

### DIFF
--- a/lib/fb_graph/ad_group.rb
+++ b/lib/fb_graph/ad_group.rb
@@ -4,7 +4,7 @@ module FbGraph
     include Connections::ReachEstimates
 
     attr_accessor :ad_id, :campaign_id, :name, :adgroup_status, :bid_type, :max_bid, :targeting, :creative, :creative_ids, :adgroup_id,
-      :end_time, :start_time, :updated_time, :bid_info, :disapprove_reason_descriptions
+      :end_time, :start_time, :updated_time, :bid_info, :disapprove_reason_descriptions, :view_tags
 
     def initialize(identifier, attributes = {})
       super
@@ -31,7 +31,7 @@ module FbGraph
     protected
 
     def set_attrs(attributes)
-      %w(ad_id campaign_id name adgroup_status bid_type max_bid targeting creative creative_ids adgroup_id bid_info disapprove_reason_descriptions).each do |field|
+      %w(ad_id campaign_id name adgroup_status bid_type max_bid targeting creative creative_ids adgroup_id bid_info disapprove_reason_descriptions view_tags).each do |field|
         send("#{field}=", attributes[field.to_sym])
       end
 

--- a/spec/fb_graph/ad_group_spec.rb
+++ b/spec/fb_graph/ad_group_spec.rb
@@ -14,7 +14,8 @@ describe FbGraph::AdGroup, '.new' do
       :adgroup_id => 6003590469668,
       :end_time => "2011-09-10T00:00:00+00:00",
       :start_time => "2011-09-01T12:00:00-07:00",
-      :updated_time => "2011-09-04T16:00:00+00:00"
+      :updated_time => "2011-09-04T16:00:00+00:00",
+      :view_tags => ["http://example.com"]
     }
     ad_group = FbGraph::AdGroup.new(attributes.delete(:id), attributes)
     ad_group.identifier.should == "6003590469668"
@@ -28,6 +29,7 @@ describe FbGraph::AdGroup, '.new' do
     ad_group.end_time.should == Time.parse("2011-09-10T00:00:00+00:00")
     ad_group.start_time.should == Time.parse("2011-09-01T12:00:00-07:00")
     ad_group.updated_time.should == Time.parse("2011-09-04T16:00:00+00:00")
+    ad_group.view_tags.should == ["http://example.com"]
   end
 end
 
@@ -48,6 +50,7 @@ describe FbGraph::AdGroup, '.fetch' do
       ad_group.end_time.should == Time.parse("2011-09-10T00:00:00+00:00")
       ad_group.start_time.should == Time.parse("2011-09-01T12:00:00-07:00")
       ad_group.updated_time.should == Time.parse("2011-09-04T16:00:00+00:00")
+      ad_group.view_tags.should == ["http://example.com"]
     end
   end
 end

--- a/spec/mock_json/ad_groups/test_ad_group.json
+++ b/spec/mock_json/ad_groups/test_ad_group.json
@@ -9,5 +9,6 @@
   "adgroup_id": 6003590469668,
   "end_time": "2011-09-10T00:00:00+00:00",
   "start_time": "2011-09-01T12:00:00-07:00",
-  "updated_time": "2011-09-04T16:00:00+00:00"
+  "updated_time": "2011-09-04T16:00:00+00:00",
+  "view_tags": ["http://example.com"]
 }


### PR DESCRIPTION
Small commit that adds an attribute to AdGroups to get [view tags](https://developers.facebook.com/docs/reference/ads-api/adgroup/#view_tags). Also updated the tests.

Thanks again!
