### PR TITLE
Some missing information in the README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -79,6 +79,10 @@ specifying the field. An example for events:
 
   user.events({:fields => "owner,name,description,picture"}) # { and } optional
 
+An overview of which fields you can include in the graph API can be found at 
+https://developers.facebook.com/docs/reference/api/, which has a description 
+of the specific objects fields in the sidebar under "Objects".
+
 ==== Search
 
   # all objects


### PR DESCRIPTION
Hi!

I was having trouble in finding out what default fields are returned with a connection, and how to include non-default fields, so I added some information in the README.rdoc that indicates how to request non-default fields for connections.

Thanks for the gem,
Claus
