### PR TITLE
Add support for `ticket_uri` field on Event

### DIFF
--- a/lib/fb_graph/event.rb
+++ b/lib/fb_graph/event.rb
@@ -10,7 +10,7 @@ module FbGraph
     include Connections::Videos
     extend Searchable
 
-    attr_accessor :owner, :name, :description, :start_time, :end_time, :location, :venue, :privacy, :updated_time
+    attr_accessor :owner, :name, :description, :start_time, :end_time, :location, :venue, :privacy, :updated_time, :ticket_uri
 
     def initialize(identifier, attributes = {})
       super
@@ -47,6 +47,7 @@ module FbGraph
       if attributes[:updated_time]
         @updated_time = Time.parse(attributes[:updated_time]).utc
       end
+      @ticket_uri = attributes[:ticket_uri]
     end
   end
 end

--- a/spec/fb_graph/event_spec.rb
+++ b/spec/fb_graph/event_spec.rb
@@ -23,7 +23,8 @@ describe FbGraph::Event do
         :longitude => '139.751'
       },
       :privacy => 'OPEN',
-      :updated_time => '2010-01-02T15:37:41+0000'
+      :updated_time => '2010-01-02T15:37:41+0000',
+      :ticket_uri => 'http://test.smart.fm/tickets',
     }
   end
   let(:event) { FbGraph::Event.new(attributes.delete(:id), attributes) }
@@ -48,6 +49,7 @@ describe FbGraph::Event do
       )
       event.privacy.should      == 'OPEN'
       event.updated_time.should == Time.parse('2010-01-02T15:37:41+0000')
+      event.ticket_uri.should   == 'http://test.smart.fm/tickets'
     end
   end
 


### PR DESCRIPTION
From https://developers.facebook.com/docs/reference/api/event/ :

Name: `ticket_uri`
Description: The URL to a location to buy tickets for this event
(on Events for Pages only)
Permissions: generic access_token, user_events or friends_events
Type: string
