### PR TITLE
Support for locale in getting Graph API.

### DIFF
--- a/lib/fb_graph/query.rb
+++ b/lib/fb_graph/query.rb
@@ -7,9 +7,11 @@ module FbGraph
       @query = query
     end
 
-    def fetch(access_token = nil)
+    def fetch(access_token = nil, locale = nil)
       handle_response do
-        http_client.get endpoint, :query => build_params(access_token)
+        query = build_params(access_token)
+        query[:locale] = locale if locale
+        http_client.get endpoint, :query => query
       end
     end
 


### PR DESCRIPTION
Hi,

I'm a Japanese programmer and I found the current fb_graph cannot handle locale for Graph API. I would like to get names represented in Japanese other than English, so I wrote this patch. The following URL shows the specification of locale support.

https://developers.facebook.com/docs/reference/api/locale/

Thanks.
