### PR TITLE
Fix pagination of the fb_graph gem

### DIFF
--- a/lib/fb_graph.rb
+++ b/lib/fb_graph.rb
@@ -3,6 +3,7 @@ require 'rack/oauth2'
 require 'patch/rack/oauth2/util'
 require 'patch/rack/oauth2/client'
 require 'patch/rack/oauth2/access_token'
+require 'CGI'
 
 module FbGraph
   VERSION = ::File.read(

--- a/lib/fb_graph/collection.rb
+++ b/lib/fb_graph/collection.rb
@@ -41,15 +41,16 @@ module FbGraph
     private
 
     def fetch_params(url)
-      query = URI.parse(URI.encode(url)).query
-      params = {}
-      query.split('&').each do |q|
-        key, value = q.split('=')
-        unless ['access_token'].include?(key)
-          params[key.to_sym] = URI.unescape(value)
+      query = URI.unescape(URI.parse(URI.encode(url)).query)
+      query_parts = CGI.parse(query)
+      {}.tap do |params|
+        query_parts.each do |key, values|
+          value = values.first
+          unless ['access_token'].include?(key)
+            params[key.to_sym] = value
+          end
         end
       end
-      params
     end
   end
 end

--- a/spec/fb_graph/collection_spec.rb
+++ b/spec/fb_graph/collection_spec.rb
@@ -57,4 +57,21 @@ describe FbGraph::Collection, '.new' do
     end
   end
 
+  it 'should handle paging params when array of ids is passed' do
+    params = {:campaign_ids => "[6001111111467]", :include_deleted => "true"}
+    mock_graph :get, '100111111111121/adgroups', 'ad_groups/test_ad_group_with_paging', :params => params do
+      ad_groups = FbGraph::AdAccount.new(100111111111121).ad_groups(params)
+      ad_groups.should be_instance_of FbGraph::Connection
+      ad_groups.should be_a FbGraph::Collection
+
+      ad_groups.collection.next.should include :offset, :campaign_ids
+      ad_groups.collection.next[:offset].should == "100"
+      eval(ad_groups.collection.next[:campaign_ids]).should == ["6001111111467"]
+
+      ad_groups.collection.previous.should include :offset, :campaign_ids
+      ad_groups.collection.previous[:offset].should == "0"
+      eval(ad_groups.collection.previous[:campaign_ids]).should == ["6001111111467"]
+    end
+  end
+
 end


### PR DESCRIPTION
The previous code used a whitelist approach to including params, but
that does not work with facebook's new paging param 'after'. It also
excludes parameters like 'include_deleted' and 'include_completed'.

This implementation excludes the only paramater that we don't want to
circulation, access_token, since that's provided by fb_graph.

Also, we would have liked to update the fb_graph-mock gem to have newer pagination examples, but did not because we don't know if facebook has completely eliminated all uses of the old params, and because we want to fix our code asap.
