### PR TITLE
Raise NotFound instead of Unauthorized for aliases that do not exist

### DIFF
--- a/lib/fb_graph/exception.rb
+++ b/lib/fb_graph/exception.rb
@@ -3,6 +3,7 @@ module FbGraph
     attr_accessor :code, :type
 
     ERROR_HEADER_MATCHERS = {
+      /not_found/ => "NotFound",
       /invalid_token/ => "InvalidToken",
       /invalid_request/ => "InvalidRequest"
     }

--- a/spec/fb_graph/exception_spec.rb
+++ b/spec/fb_graph/exception_spec.rb
@@ -124,6 +124,26 @@ describe FbGraph::Exception, ".handle_httpclient_error" do
         lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, headers)}.should raise_exception(FbGraph::InvalidRequest)
       end
     end
+
+    context "to an an alias that does not exist" do
+      let(:parsed_response) do
+        {
+          :error => {
+            :message => '(#803) Some of the aliases you requested do not exist: test',
+            :type => "OAuthException"
+          }
+        }
+      end
+      let(:headers) do
+        {
+          "WWW-Authenticate" =>'OAuth "Facebook Platform" "not_found" "(#803) Some of the aliases you requested do not exist: test"'
+        }
+      end
+
+      it "should raise a NotFound exception" do
+        lambda {FbGraph::Exception.handle_httpclient_error(parsed_response, headers)}.should raise_exception(FbGraph::NotFound)
+      end
+    end
   end
 
   context "without the WWW-Authenticate header" do


### PR DESCRIPTION
Hi @nov!

Thanks for your work. I've noticed that FbGraph raises `Unauthorized` upon encountering aliases that don't exist ([example](http://graph.facebook.com/thispagereallydoesnotexist)), but I would argue that `NotFound` is a more appropriate exception.

PS: The spec that fails in unrelated and was already failing.
