### PR TITLE
Add error code accessors to exception

### DIFF
--- a/spec/fb_graph/exception_spec.rb
+++ b/spec/fb_graph/exception_spec.rb
@@ -7,16 +7,19 @@ describe FbGraph::Exception do
   end
 
   context 'when response body is given' do
-    it 'should setup message and type from error' do
+    it 'should setup type, error code, and subcode from error' do
       err = FbGraph::Exception.new(400, 'This is the original message', {
         :error => {
           :type => 'SomeError',
-          :message => 'This is the error message'
+          :message => 'This is the error message',
+          :code => 190,
+          :error_subcode => 460
         }
-      }.to_json)
+      })
       err.code.should == 400
       err.type.should == 'SomeError'
-      err.message.should == 'This is the error message'
+      err.error_code.should == 190
+      err.error_subcode.should == 460
     end
   end
 


### PR DESCRIPTION
Sometimes, the best way of handling an error from the FB Graph API is to perform an action based on the error code that they provide (see [the FB error docs](http://developers.facebook.com/docs/reference/api/errors/)).  Additionally, often an application should take different actions based on the code or subcode.

This PR simply records the code and the subcode (if any) provided by FB, and makes it available in an accessor.  I was also working on code to provide the mapping to the Error Recovery Tactics listed on [the documentation page](http://developers.facebook.com/docs/reference/api/errors/), but I quickly realized that not all of the error codes that can be returned from facebook are listed on that page.  If you have any ideas on how to handle unknowns, let me know and I'll push up the commit
