### PR TITLE
Adds tab_for_app method to tabs connection

### DIFF
--- a/lib/fb_graph/connections/tabs.rb
+++ b/lib/fb_graph/connections/tabs.rb
@@ -18,6 +18,14 @@ module FbGraph
         tab = self.connection :tabs, options.merge(:connection_scope => application.identifier)
         tab.present?
       end
+
+      def tab_for_app(application, options = {})
+        response = get options.merge(:connection => :tabs, :connection_scope => application.identifier)
+        tab = response[:data].first
+        Tab.new tab[:id], tab.merge(
+          :access_token => options[:access_token] || self.access_token
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes nov/fb_graph#341 by adding an `tab_for_app` method to the tabs connection. Creation flow for tabs now looks something like this:

``` ruby
if page.tab! params
  tab = page.tab_for_app my_application
else
  #failure case
end
```
