### PR TITLE
adding is_eligible_promo flag for payer promotions

### DIFF
--- a/lib/fb_graph/user.rb
+++ b/lib/fb_graph/user.rb
@@ -53,7 +53,7 @@ module FbGraph
         :verified, :about, :bio, :email, :political, :quotes,
         :relationship_status, :relationship, :video_upload_limits,
         :website, :mobile_phone, :installed, :rsvp_status,
-        :security_settings, :currency, :religion
+        :security_settings, :currency, :religion, :is_eligible_promo
       ],
       :custom => [
         :languages, :like_count, :updated_time,


### PR DESCRIPTION
Payer promotion eligibility flag can be queried using the "fields" parameter with the fetch() method.

Find more information about payer promotions here:
https://developers.facebook.com/docs/concepts/payerpromotions/
