### PR TITLE
If Facebook returns [], gem should return []. Fixes #350

### DIFF
--- a/lib/fb_graph/node.rb
+++ b/lib/fb_graph/node.rb
@@ -143,6 +143,8 @@ module FbGraph
           #  When MultiJson.engine is JsonGem, parsing JSON String fails.
           #  You should handle this case without MultiJson.
           response.body.gsub('"', '')
+        elsif response.body.strip == "[]"
+          []
         else
           MultiJson.load(response.body).with_indifferent_access
         end


### PR DESCRIPTION
See #350 - Facebook returns "[]" for some responses. Gem should accept them happily in this case?
