### PR TITLE
Support the new v2 API permissions format.

### DIFF
--- a/lib/fb_graph/connections/permissions.rb
+++ b/lib/fb_graph/connections/permissions.rb
@@ -2,10 +2,17 @@ module FbGraph
   module Connections
     module Permissions
       def permissions(options = {})
-        self.connection(:permissions, options).first.try(:inject, []) do |arr, (key, value)|
-          arr << key.to_sym if value.to_i == 1
-          arr
-        end || []
+        if FbGraph.v2?
+          self.connection(:permissions, options).try(:inject, []) do |arr, entry|
+            arr << entry[:permission].to_sym if entry[:status] == 'granted'
+            arr
+          end || []
+        else
+          self.connection(:permissions, options).first.try(:inject, []) do |arr, (key, value)|
+            arr << key.to_sym if value.to_i == 1
+            arr
+          end || []
+        end
       end
 
       def revoke!(permission = nil, options = {})

--- a/spec/fb_graph/connections/permissions_spec.rb
+++ b/spec/fb_graph/connections/permissions_spec.rb
@@ -2,23 +2,65 @@ require 'spec_helper'
 
 describe FbGraph::Connections::Permissions do
   describe '#permissions' do
-    let :permissions do
-      mock_graph :get, 'me/permissions', 'users/permissions/me_private', :access_token => 'access_token' do
-        FbGraph::User.me('access_token').permissions
+
+    context 'v1 API' do
+      let :permissions do
+        mock_graph :get, 'me/permissions', 'users/permissions/me_private', :access_token => 'access_token' do
+          FbGraph::User.me('access_token').permissions
+        end
+      end
+
+      it 'should be an Array of Symbol' do
+        permissions.should be_instance_of Array
+        permissions.should_not be_blank
+        permissions.each do |permission|
+          permission.should be_instance_of Symbol
+        end
+      end
+
+      context 'when blank' do
+        it 'should return blank array' do
+          mock_graph :get, 'me/permissions', 'users/permissions/blank', :access_token => 'access_token' do
+            permissions = FbGraph::User.me('access_token').permissions
+            permissions.should == []
+          end
+        end
       end
     end
 
-    it 'should be an Array of Symbol' do
-      permissions.should be_instance_of Array
-      permissions.should_not be_blank
-      permissions.each do |permission|
-        permission.should be_instance_of Symbol
+    context 'v2 API' do
+      def mock_v2_graph(response)
+        stub_request(
+          :get,
+          File.join(FbGraph::ROOT_URL, 'v2.0', 'me', 'permissions')
+        ).with(
+          request_for(:get, { :params => { :access_token => 'access_token' } })
+        ).to_return(
+          { body: response }
+        )
       end
-    end
 
-    context 'when blank' do
-      it 'should return blank array' do
-        mock_graph :get, 'me/permissions', 'users/permissions/blank', :access_token => 'access_token' do
+      before(:each) do
+        FbGraph.v2!
+      end
+
+      after(:each) do
+        FbGraph.v1!
+      end
+
+      it 'should be an Array of Hash' do
+        mock_v2_graph("{\"data\":[{\"permission\":\"installed\",\"status\":\"granted\"},{\"permission\": \"public_profile\",\"status\": \"granted\"}]}")
+        permissions = FbGraph::User.me('access_token').permissions
+        permissions.should be_instance_of Array
+        permissions.should_not be_blank
+        permissions.each do |permission|
+          permission.should be_instance_of Symbol
+        end
+      end
+
+      context 'when blank' do
+        it 'should return blank array' do
+          mock_v2_graph("{\"data\":[]}")
           permissions = FbGraph::User.me('access_token').permissions
           permissions.should == []
         end


### PR DESCRIPTION
Facebook v2 API permissions are returned in a different format to v1. See [v1](https://developers.facebook.com/docs/graph-api/reference/v1.0/user/permissions) vs. [v2](https://developers.facebook.com/docs/graph-api/reference/v2.0/user/permissions) documentation.

Instead of:

```
{ "publish_actions": 1, ... }
```

... we now get:

```
[{ "permission": "publish_actions", "status": "granted" }, ...]
```

I was hesitant to dive into adding v2 support in [fb_graph-mock](https://github.com/nov/fb_graph-mock), so the tests are a bit of a hack.
