### PR TITLE
Fetch images from a post + refactoring

### DIFF
--- a/spec/fb_graph/post_spec.rb
+++ b/spec/fb_graph/post_spec.rb
@@ -29,6 +29,15 @@ describe FbGraph::Post, '.new' do
         }]
       },
       :icon => "http://photos-d.ak.fbcdn.net/photos-ak-snc1/v27562/23/2231777543/app_2_2231777543_9553.gif",
+      :images => [{
+        :height => 688,
+        :source => "https://scontent-a.xx.fbcdn.net/hphotos-xpa1/v/t1.0-9/10561773_10152440606793600_1776025110345181258_n.jpg?oh=4906f82b8953e685cf8162317ab38d87&oe=54405E40",
+        :width  => 957
+      }, {
+        :height => 600,
+        :source => "https://scontent-a.xx.fbcdn.net/hphotos-xpa1/v/t1.0-9/p600x600/10561773_10152440606793600_1776025110345181258_n.jpg?oh=cbe12447649d45c852f8ebdec604905e&oe=54568A70",
+        :width  => 834
+      }],
       :type => "status",
       :object_id => "12345",
       :actions => [{
@@ -79,6 +88,18 @@ describe FbGraph::Post, '.new' do
     post.properties.each do |property|
       property.should be_a FbGraph::Property
     end
+    post.images.should == [
+      FbGraph::Image.new(
+        :height => 688,
+        :source => "https://scontent-a.xx.fbcdn.net/hphotos-xpa1/v/t1.0-9/10561773_10152440606793600_1776025110345181258_n.jpg?oh=4906f82b8953e685cf8162317ab38d87&oe=54405E40",
+        :width  => 957
+      ),
+      FbGraph::Image.new(
+        :height => 600,
+        :source => "https://scontent-a.xx.fbcdn.net/hphotos-xpa1/v/t1.0-9/p600x600/10561773_10152440606793600_1776025110345181258_n.jpg?oh=cbe12447649d45c852f8ebdec604905e&oe=54568A70",
+        :width  => 834
+      )
+    ]
     post.actions.should == [
       FbGraph::Action.new(
         :name => "Comment",


### PR DESCRIPTION
Fetches images from a post.

Example form [FB graph](https://graph.facebook.com/10152440606793600/):

```
   "images": [
      {
         "height": 688,
         "source": "https://scontent-a.xx.fbcdn.net/hphotos-xpa1/v/t1.0-9/10561773_10152440606793600_1776025110345181258_n.jpg?oh=4906f82b8953e685cf8162317ab38d87&oe=54405E40",
         "width": 957
      }, ...
    ]

```

How to reproduce:

```
[8] pry(main)> post = FbGraph::Post.new('10152440606793600', access_token: access_token).fetch
=> #<FbGraph::Post:0x007fe682be9e50 ...>
[9] pry(main)> post.images
NoMethodError: undefined method `images' for #<FbGraph::Post:0x007fe682be9e50>
[10] pry(main)> post.raw_attributes['images']
=> [{"height"=>688,
  "source"=>
   "https://scontent-a.xx.fbcdn.net/hphotos-xpa1/v/t1.0-9/10561773_10152440606793600_1776025110345181258_n.jpg?oh=4906f82b8953e685cf8162317ab38d87&oe=54405E40",
  "width"=>957}, ...]
```

So, I did small refactoring according to [new style](https://github.com/nov/fb_graph/blob/master/lib/fb_graph/ad_campaign_group.rb#L18-L20) and added fetching of images
